### PR TITLE
Add app_id as a param so that it is eaiser to test

### DIFF
--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -3,8 +3,12 @@
 import { FormEvent, useState } from 'react'
 import { OneSignalAppID } from '@/core/constants'
 import { safeTry } from '@/core/utils'
+import { useSearchParams } from 'next/navigation'
+
 
 export default function SignUpPage() {
+  const searchParams = useSearchParams()
+
   const [formData, setFormData] = useState({
     name: '',
     email: '',
@@ -151,8 +155,9 @@ export default function SignUpPage() {
 
   async function submitForm(event: FormEvent) {
     event.preventDefault()
-
-    const createUserAPI = `https://api.onesignal.com/apps/${OneSignalAppID}/users`
+    // Use the app_id query parameter if it exists, otherwise use the default OneSignalAppID
+    const appId = searchParams.get('app_id') || OneSignalAppID
+    const createUserAPI = `https://api.onesignal.com/apps/${appId}/users`
     const subscriptionsToCreate: Array<{
       type: string
       token: string


### PR DESCRIPTION
Adding `app_id` as an optional url param to make it so you dont need to run it locally to change the app id for testing/demos